### PR TITLE
Fix go to line when creating a spec

### DIFF
--- a/plugin_helpers/open_file.py
+++ b/plugin_helpers/open_file.py
@@ -1,4 +1,5 @@
 import functools
+import sublime
 
 class OpenFile(object):
   def __init__(self, window, files):
@@ -7,7 +8,7 @@ class OpenFile(object):
 
   def run(self):
     if self._single_file():
-      self.window.open_file(self.files[0])
+      self.window.open_file(self.files[0], sublime.ENCODED_POSITION)
     else:
       self.window.show_quick_panel(self.files, self._callback())
 
@@ -20,4 +21,4 @@ class OpenFile(object):
   def _on_selected(self, files, index):
     if index == -1: return
 
-    self.window.open_file(files[index])
+    self.window.open_file(files[index], sublime.ENCODED_POSITION)

--- a/rspec/create_spec_file.py
+++ b/rspec/create_spec_file.py
@@ -27,11 +27,10 @@ class CreateSpecFile(object):
     handler.close()
 
   def _open(self):
-    OpenFile(self.context.window(), self._file_name()).run()
-    self.context.window().active_view().run_command(
-      "goto_line",
-      { "line": self.context.from_settings("create_spec_cursor_line") }
-    )
+    OpenFile(
+      self.context.window(),
+      "{}:{}".format(self._file_name(), self._create_spec_cursor_line())
+    ).run()
 
   @memoize
   def _file_name(self):
@@ -51,6 +50,10 @@ class CreateSpecFile(object):
   @memoize
   def _spec_folder(self):
     return self.context.from_settings("spec_folder")
+
+  @memoize
+  def _create_spec_cursor_line(self):
+    return self.context.from_settings("create_spec_cursor_line")
 
   @memoize
   def _spec_template(self):

--- a/test_rspec.py
+++ b/test_rspec.py
@@ -75,6 +75,6 @@ class SwitchBetweenCodeAndTestCommand(sublime_plugin.TextCommand):
 
 class CreateSpecFileCommand(sublime_plugin.TextCommand):
   def run(self, edit):
-    rspec_print("Creating sepc file")
+    rspec_print("Creating spec file")
     context = TaskContext(self, edit)
     CreateSpecFile(context).run()


### PR DESCRIPTION
`goto_line` command has no effect. [Documentation](https://www.sublimetext.com/docs/3/api_reference.html#sublime.Window) seems to give a reason for this:

> Note that as file loading is asynchronous, operations on the returned view won't be possible until its is_loading() method returns False.

Found an alternative apporach: pass `/path/to/file.rb:line_number` as an argument for `open_file`, it so that is goes to the specified line after it's opened.

@astrauka 