### PR TITLE
Focus to output panel after test

### DIFF
--- a/rspec/execute_spec.py
+++ b/rspec/execute_spec.py
@@ -12,6 +12,7 @@ class ExecuteSpec(object):
     self._validate_can_run_spec()
     self._prepare_output_panel()
     self._execute(self._command_hash())
+    self.context.window().focus_view(self.context.window().find_output_panel("exec"))
 
   def last_run(self):
     self._execute(LastRun.command_hash())


### PR DESCRIPTION
In RSpec test, often the feedback is more than one screen can fit even if the output panel is maximized. We need to scroll up and down to read the information. In order not to move our hands away from keyboard, it's nice to have the output panel focused after the test is run such that we can scroll up and down right away using keyboard.

This change will affect **Test Current Line** and **Test Current File**.

Another related useful feature is reopen the output panel and focus on it. We need to maximize the panel to read the test feedback. After that in order to code, we have to close it. Often we need to recheck what the error message is which makes this feature useful. This is a small but yet independent feature. This feature could be useful to other needs with other plugins. Might as well leave it as a separate plugin instead of merging it to yours. What you think?