### PR TITLE
Allow for spaces in project root directory

### DIFF
--- a/rspec/execute_spec.py
+++ b/rspec/execute_spec.py
@@ -57,7 +57,7 @@ class ExecuteSpec(object):
     add_to_path = self.context.from_settings("rspec_add_to_path", "")
     append_path = "export PATH={0}:$PATH;".format(add_to_path) if add_to_path else ""
 
-    command = "({append_path} cd {project_root} && {rspec_command} {target})".format(
+    command = "({append_path} cd '{project_root}' && {rspec_command} {target})".format(
       append_path = append_path,
       project_root = self.context.project_root(),
       rspec_command = SpecCommand(self.context).result(),


### PR DESCRIPTION
Using `cd` without surrounding the argument with quotes is not necessarily possible 
especially on operating systems like macOS which allow spaces in directory names:

`/Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/dev`

Prior to this change attempting to run TestRSpec on a spec file would cause: 

```
bash: line 0: cd: too many arguments
[Finished in 3.3s with exit code 1]
[shell_cmd: ( cd /Users/olivierlacan/Library/Mobile Documents/com~apple~CloudDocs/dev && ./bin/rspec spec/example_spec.rb)]
```
 
I find myself forced to have a `pwd` with a space because Apple insists on naming the internal directory where iCloud Drive runs `~/Library/Mobile Documents/com~apple~CloudDocs/`. It's annoying but I can't really do anything about it if I want the development folder I'm working off of to be synced with iCloud.