### PR TITLE
Combine default and user settings menu entries

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -45,26 +45,23 @@
             "id": "sublime-rspec",
             "children": [
               {
-                  "command": "open_file",
-                  "args": {"file": "${packages}/TestRSpec/Preferences.sublime-settings"},
-                  "caption": "Settings – Default"
+                "caption": "Settings",
+                "command": "edit_settings",
+                "args": {
+                  "base_file": "${packages}/TestRSpec/Preferences.sublime-settings",
+                  "user_file": "${packages}/User/TestRSpec.sublime-settings",
+                  "default": ""
+                }
               },
               {
-                  "command": "open_file",
-                  "args": {"file": "${packages}/User/TestRSpec.sublime-settings"},
-                  "caption": "Settings – User"
-              },
-              { "caption": "-" },
-              {
-                  "command": "open_file",
-                  "args": {"file": "${packages}/TestRSpec/Default.sublime-keymap"},
-                  "caption": "Key Bindings – Default"
-              },
-              {
-                  "command": "open_file",
-                  "args": {"file": "${packages}/User/Default (${platform}).sublime-keymap"},
-                  "caption": "Key Bindings – User"
-              },
+                "caption": "Key Bindings",
+                "command": "edit_settings",
+                "args": {
+                  "base_file": "${packages}/TestRSpec/Default.sublime-keymap",
+                  "user_file": "${packages}/User/Default (${platform}).sublime-keymap",
+                  "default": ""
+                }
+              }
             ]
           }
         ]


### PR DESCRIPTION
`edit_settings` is a command introduced in build 3124 which opens default and user settings files side by side. Very convenient.

<img src="https://user-images.githubusercontent.com/544537/37553289-b59daf80-29cd-11e8-9ac1-42f48abf38ac.png" width="361">

<img src="https://user-images.githubusercontent.com/544537/37553317-450faef2-29ce-11e8-9611-f9bab89a87f0.png" width="1188">