### PR TITLE
Fix space in path issues on windows

### DIFF
--- a/plugin_helpers/utils.py
+++ b/plugin_helpers/utils.py
@@ -60,5 +60,5 @@ def quote(s):
 
 def _quote_windows_string(s):
   if not s:
-    return "\"\""
-  return "\""+s.replace("\"", "\\\"")+"\""
+    return '""'
+  return '"' + s.replace('"', '\\"') + '"'

--- a/plugin_helpers/utils.py
+++ b/plugin_helpers/utils.py
@@ -1,5 +1,8 @@
 # from http://code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
 
+import platform
+import shlex
+
 from functools import partial
 
 class memoize(object):
@@ -48,3 +51,14 @@ def unique(seq):
 def rreplace(s, old, new, occurrence):
   li = s.rsplit(old, occurrence)
   return new.join(li)
+
+def quote(s):
+  if "windows" in platform.system().lower():
+    return _quote_windows_string(s)
+  else:
+    return shlex.quote(s)
+
+def _quote_windows_string(s):
+  if not s:
+    return "\"\""
+  return "\""+s.replace("\"", "\\\"")+"\""

--- a/rspec/execute_spec.py
+++ b/rspec/execute_spec.py
@@ -1,4 +1,4 @@
-from shlex import quote
+from plugin_helpers.utils import quote
 from plugin_helpers.utils import memoize
 from rspec.output import Output
 from rspec.spec_command import SpecCommand


### PR DESCRIPTION
# Description

Changes introduced in version 1.0.8 lead to a regression which rendered the plugin unusable in Windows. This change fixes the windows issues and adds support for spaces in paths to windows.

* Quote strings with double quotes on windows systems
* use shlex.quote otherwise

Fixes #36 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Notes to the reviewer

This change only introduces minimal escaping to the windows string. There is practically no input sanitization. However I think that the exposed attack surface is limited and the potential damage is also quite small.

# How Has This Been Tested?

- [x] Run a spec file on Windows 10 (cmd, no space in path -> executes with double quoted string
- [x] Run a spec file on Windows 10 (cmd), with space in path -> executes with double quoted string
- [x] Run a spec file on Ubuntu 16.04  , no space in path -> executes with single quoted string
- [x] Run a spec file on Ubuntu 16.04  , with space in path  -> executes with single quoted string

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules