### PR TITLE
Allow to specify the log level and log to the console

### DIFF
--- a/TestRSpec.sublime-settings
+++ b/TestRSpec.sublime-settings
@@ -53,4 +53,8 @@
   "create_spec_class_name_regexp": "(class|module)[ ]+([a-zA-Z0-9:]*)",
   // if there is an exact match then directly jump to that one, show dropdown otherwise
   "switch_code_test_immediately_on_direct_match": true,
+  // can be ERROR, WARNING or INFO
+  "log_level": "INFO",
+  // write logs to the output panel or the console
+  "log_to_console": false,
 }


### PR DESCRIPTION
This PR addresses two things(I am happy to split it into two separate PRs but they are kind of related)
First, it adds the ability to output the logs to the Sublime console.
It is useful when the `target` setting is different from `exec` and you don't want an output panel to be created.
It also allows specifying the log level so INFO messages can be ignored