### PR TITLE
Add setting to ignore nested classes

### DIFF
--- a/TestRSpec.sublime-settings
+++ b/TestRSpec.sublime-settings
@@ -51,6 +51,8 @@
   "spec_file_extension": "_spec.rb",
   // regexp used to determine class name once creating new spec file
   "create_spec_class_name_regexp": "(class|module)[ ]+([a-zA-Z0-9:]*)",
+  // if nested classes should be ignored when creating a new spec file
+  "ignore_nested_classes": true,
   // if there is an exact match then directly jump to that one, show dropdown otherwise
   "switch_code_test_immediately_on_direct_match": true,
   // can be ERROR, WARNING or INFO

--- a/rspec/create_spec_file.py
+++ b/rspec/create_spec_file.py
@@ -82,7 +82,11 @@ class CreateSpecFile:
         names = []
         for descriptor, name in matches:
             names.append(name)
-            if descriptor == self.CLASS_DESCRIPTOR:
+            if self._ignore_nested_classes() and descriptor == self.CLASS_DESCRIPTOR:
                 break
 
         return "::".join(names)
+    
+    @memoize
+    def _ignore_nested_classes(self):
+        return self.context.from_settings("ignore_nested_classes")


### PR DESCRIPTION
Hi :)

First of all, I barely know any Python and only edited this using the GitHub UI. I love this package, but I personally need spec files for a lot of nested classes. The needed folder structure is supported, but when creating the spec the template class name breaks too early for me. To not change existing behavior I added a setting that determines whether the current behavior should stay (default), or whether nested classes should be counted for the class name.

This would be an amazing edition for me!

Thank you! 